### PR TITLE
Remove numpy

### DIFF
--- a/pyfastaq/common.py
+++ b/pyfastaq/common.py
@@ -1,1 +1,1 @@
-version = '3.9.0'
+version = '3.10.0'

--- a/pyfastaq/tests/tasks_test.py
+++ b/pyfastaq/tests/tasks_test.py
@@ -271,15 +271,6 @@ class TestMakeRandomContigs(unittest.TestCase):
         os.unlink(tmp)
 
 
-class TestMakeLongReads(unittest.TestCase):
-    def test_tiling_reads(self):
-        tmp = 'tmp.out.fa'
-        fa_in = os.path.join(data_dir, 'tasks_test_make_long_reads.input.fa')
-        tasks.make_long_reads(fa_in, tmp, method='tiling', fixed_read_length=10, tile_step=5)
-        self.assertTrue(filecmp.cmp(os.path.join(data_dir, 'tasks_test_make_long_reads.output.fa'), tmp, shallow=False))
-        os.unlink(tmp)
-
-
 class TestMeanLength(unittest.TestCase):
     def test_mean_length(self):
         '''Test mean_length'''

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyfastaq',
-    version='3.9.0',
+    version='3.10.0',
     description='Script to manipulate FASTA and FASTQ files, plus API for developers',
     packages = find_packages(),
     author='Martin Hunt',
@@ -13,7 +13,6 @@ setup(
     scripts=glob.glob('scripts/*'),
     test_suite='nose.collector',
     tests_require=['nose >= 1.3'],
-    install_requires=['numpy >= 1.7.1'],
     license='GPLv3',
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This PR removes the dependency on numpy. It has been causing install issues with Circlator and IVA (which don't need numpy). Only one fastaq task required numpy, and it was probably only used by me anyway.