### PR TITLE
Add check_comments option to filter

### DIFF
--- a/pyfastaq/runners/filter.py
+++ b/pyfastaq/runners/filter.py
@@ -10,6 +10,7 @@ def run(description):
     parser.add_argument('--regex', help='If given, only reads with a name matching the regular expression will be kept')
     parser.add_argument('--ids_file', help='If given, only reads whose ID is in th given file will be used. One ID per line of file.', metavar='FILENAME')
     parser.add_argument('-v', '--invert', action='store_true', help='Only keep sequences that do not match the filters')
+    parser.add_argument('--check_comments', action='store_true', help='Search the header comments also for the given regex. Can only be specified with --regex')
 
     mate_group = parser.add_argument_group('Mate file for read pairs options')
     mate_group.add_argument('--mate_in', help='Name of mates input file. If used, must also provide --mate_out', metavar='FILENAME')
@@ -29,4 +30,5 @@ def run(description):
                  mate_in=options.mate_in,
                  mate_out=options.mate_out,
                  both_mates_pass=options.both_mates_pass,
+                 check_comments=options.check_comments,
     )

--- a/pyfastaq/tasks.py
+++ b/pyfastaq/tasks.py
@@ -6,6 +6,11 @@ from pyfastaq import sequences, utils, caf
 
 class Error (Exception): pass
 
+
+class IncompatibleParametersError(Exception):
+    pass
+
+
 def acgtn_only(infile, outfile):
     '''Replace every non-acgtn (case insensitve) character with an N'''
     f = utils.open_file_write(outfile)
@@ -284,7 +289,12 @@ def filter(
       mate_in=None,
       mate_out=None,
       both_mates_pass=True,
+      check_comments=False
     ):
+    if check_comments and not regex:
+        raise IncompatibleParametersError(
+            "--check_comments can only be passed with --regex"
+        )
 
     ids_from_file = set()
     if ids_file is not None:
@@ -309,7 +319,7 @@ def filter(
     def passes(seq, name_regex):
         # remove trailing comments from FASTQ readname lines
         matches = name_regex.match(seq.id)
-        if matches is not None:
+        if matches is not None and not check_comments:
             clean_seq_id = matches.group(1)
         else:
             clean_seq_id = seq.id


### PR DESCRIPTION
This PR adds a `--check_comments` parameter to `fastaq filter`.

**Example:**  
I have a Canu assembly with a bunch of contigs. 

```
>tig00000730 len=11258 reads=4 class=contig suggestRepeat=no suggestBubble=yes suggestCircular=no
>tig00000733 len=8684 reads=3 class=contig suggestRepeat=no suggestBubble=no suggestCircular=no
```

I would like to remove any contigs that might be bubbles - `suggestBubble=yes`.  

The addition of the `--check_comments` flag allows me to extract non-bubble contigs with

```sh
fastaq filter --regex "suggestBubble=no" --check_comments asm.fa asm.nobubbles.fa 
```

*Note: `--check_comments` can only be passed at the same time as `--regex`*