### PR TITLE
Migrate to importlib.metadata.

### DIFF
--- a/pyfastaq/__init__.py
+++ b/pyfastaq/__init__.py
@@ -1,11 +1,12 @@
 try:
     from importlib.metadata import Distribution
     __version__ = Distribution().from_name('pyfastaq').version
-except ImportError:
-    from pkg_resources import get_distribution
-    __version__ = get_distribution('pyfastaq').version
 except:
-    __version__ = 'local'
+    try:
+        from pkg_resources import get_distribution
+        __version__ = get_distribution('pyfastaq').version
+    except:
+        __version__ = 'local'
 
 
 

--- a/pyfastaq/__init__.py
+++ b/pyfastaq/__init__.py
@@ -1,6 +1,8 @@
-from pkg_resources import get_distribution
-
 try:
+    from importlib.metadata import Distribution
+    __version__ = Distribution().from_name('pyfastaq').version
+except ImportError:
+    from pkg_resources import get_distribution
     __version__ = get_distribution('pyfastaq').version
 except:
     __version__ = 'local'


### PR DESCRIPTION
As initially identified in [Debian bug #1083383], Fastaq depends on the Python module pkg_resources, [deprecated] since python3.11 and obsoleted in python3.13, in favor of [importlib.metadata], available since python3.8.

In case Fastaq still needs to cover ancient Python interpreter versions preceeding 3.8, the change also includes a fallback to pkg_resources if the importlib is not located properly.

[Debian bug #1083383]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1083383
[deprecated]: https://setuptools.pypa.io/en/latest/pkg_resources.html
[importlib.metadata]: https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata